### PR TITLE
fix/pray-date-category-input

### DIFF
--- a/src/components/PrayDateCategoryInput/PrayDateCategoryInput.js
+++ b/src/components/PrayDateCategoryInput/PrayDateCategoryInput.js
@@ -40,15 +40,17 @@ const PrayDateCategoryInput = ({
   }, [showSubModal]);
 
   useEffect(() => {
+    setSelectedCategoryIndex(category);
+  }, [category]);
+
+  useEffect(() => {
     setUpdateCategory(selectedCategoryIndex);
   }, [selectedCategoryIndex]);
 
   const onInputHandler = (e) => {
     const isWhitespace = /^\s*$/.test(e.target.value);
-    if (isWhitespace)
-      setInputCount(0);
-    else
-      setInputCount(e.target.value.length);
+    if (isWhitespace) setInputCount(0);
+    else setInputCount(e.target.value.length);
 
     if (setUpdateValue) setUpdateValue(e.target.value);
   };

--- a/src/components/PrayDateCategoryInput/PrayDateCategoryInput.js
+++ b/src/components/PrayDateCategoryInput/PrayDateCategoryInput.js
@@ -141,11 +141,11 @@ export default PrayDateCategoryInput;
 const SubModalWrapper = styled.div`
   position: fixed;
   justify-content: space-between;
-  left: 50%;
-  top: 50%;
-  height: calc(100vh - 32px);
-  transform: translate(-50%, -50%);
-  width: calc(100vw - 32px);
+  top: 0;
+  left: 0;
+  height: calc(100% - 32px);
+  width: calc(100% - 32px);
+  padding: 16px;
   display: flex;
   flex-direction: column;
   z-index: 500;
@@ -197,8 +197,6 @@ const Countwords = styled.span`
 `;
 
 const FixedButtonContainer = styled.div`
-  position: fixed;
-  bottom: 0px;
   width: 100%;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
1. [fix: praydatecategoryinput 켜질 때 카테고리 선택이 안 되는 오류 수정](https://github.com/PrayHelper/uspray-frontend/pull/276/commits/c21d41e643507c987aa2c031c82e23e8b44f99df)
[WVQZ-124](https://uspray.atlassian.net/browse/WVQZ-124)

`const [selectedCategoryIndex, setSelectedCategoryIndex] = useState(category);` 
category로 선택된 상태로 켜지게끔 했는데,
작동이 안 되는 것 같아서

`useEffect(() => {
    setSelectedCategoryIndex(category);
  }, [category]);`

category 바뀔 때마다 적용이 되도록 수정했습니다


2. [fix: 마리오 효과 없애기](https://github.com/PrayHelper/uspray-frontend/pull/276/commits/3a807891634b4077344f4f69a55bed7eecfdf075)
[WVQZ-77](https://uspray.atlassian.net/browse/WVQZ-77)